### PR TITLE
fix: update to Node.js 22

### DIFF
--- a/cdk/WebhookReceiverStack.ts
+++ b/cdk/WebhookReceiverStack.ts
@@ -45,7 +45,7 @@ export class WebhookReceiverStack extends Stack {
 				),
 			],
 			handler: lambdaSource.handler,
-			runtime: Lambda.Runtime.NODEJS_20_X,
+			runtime: Lambda.Runtime.NODEJS_22_X,
 			architecture: Lambda.Architecture.ARM_64,
 			timeout: Duration.seconds(15),
 			initialPolicy: [


### PR DESCRIPTION
See https://aws.amazon.com/de/blogs/compute/node-js-22-runtime-now-available-in-aws-lambda/
